### PR TITLE
Fix Android build with NDK 26

### DIFF
--- a/load_ogg.c
+++ b/load_ogg.c
@@ -86,10 +86,10 @@ SDL_AudioSpec *Mix_LoadOGG_RW (SDL_RWops *src, int freesrc,
         goto done;
 
     callbacks.read_func = sdl_read_func;
-    callbacks.seek_func = sdl_seek_func;
+    callbacks.seek_func = (int (*)(void *, ogg_int64_t, int)) sdl_seek_func;
     callbacks.tell_func = sdl_tell_func;
-    callbacks.close_func = freesrc ?
-                           sdl_close_func_freesrc : sdl_close_func_nofreesrc;
+    callbacks.close_func = (int (*)(void *)) (freesrc ?
+                                              sdl_close_func_freesrc : sdl_close_func_nofreesrc);
 
     if (vorbis.ov_open_callbacks(src, &vf, NULL, 0, callbacks) != 0)
     {

--- a/music_ogg.c
+++ b/music_ogg.c
@@ -78,7 +78,7 @@ OGG_music *OGG_new_RW(SDL_RWops *src, int freesrc)
 
     SDL_memset(&callbacks, 0, sizeof(callbacks));
     callbacks.read_func = sdl_read_func;
-    callbacks.seek_func = sdl_seek_func;
+    callbacks.seek_func = (int (*)(void *, ogg_int64_t, int)) sdl_seek_func;
     callbacks.tell_func = sdl_tell_func;
 
     music = (OGG_music *)SDL_malloc(sizeof *music);


### PR DESCRIPTION
This change is required to build the Android port with NDK 26.